### PR TITLE
Fix/userdata update

### DIFF
--- a/src/articles/dto/create-article.dto.ts
+++ b/src/articles/dto/create-article.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { Transform } from "class-transformer";
-import { IsBoolean, IsNotEmpty, IsOptional } from "class-validator";
+import { IsBoolean, IsNotEmpty, IsOptional, Length } from "class-validator";
 
 export class CreateArticleDto {
   @ApiProperty({
@@ -10,6 +10,7 @@ export class CreateArticleDto {
   @IsNotEmpty({
     message: "title 為必填欄位。",
   })
+  @Length(1, 255, { message: "email 長度只能 1-255 個字元。" })
   public readonly title: string;
 
   @ApiProperty({
@@ -19,6 +20,7 @@ export class CreateArticleDto {
   @IsNotEmpty({
     message: "subtitle 為必填欄位。",
   })
+  @Length(1, 255, { message: "email 長度只能 1-255 個字元。" })
   public readonly subtitle: string;
 
   @ApiProperty({

--- a/src/auth/dto/auth-confirm-dto.ts
+++ b/src/auth/dto/auth-confirm-dto.ts
@@ -10,6 +10,7 @@ export class AuthConfirmDto {
   @IsNotEmpty({
     message: "email 為必填欄位。",
   })
+  @Length(1, 255, { message: "email 長度只能 1-255 個字元。" })
   public readonly email: string;
 
   @ApiProperty({

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -24,6 +24,7 @@ export class CreateUserDto {
   @IsNotEmpty({
     message: "username 為必填欄位。",
   })
+  @Length(1, 10, { message: "username 長度只能 1-10 個字元。" })
   public readonly username: string;
 
   @ApiProperty({
@@ -34,5 +35,6 @@ export class CreateUserDto {
   @IsNotEmpty({
     message: "email 為必填欄位。",
   })
+  @Length(1, 255, { message: "email 長度只能 1-255 個字元。" })
   public readonly email: string;
 }

--- a/src/users/dto/patch-user-img.dto.ts
+++ b/src/users/dto/patch-user-img.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsString } from "class-validator";
+import { IsString, Length } from "class-validator";
 
 export class PatchUserImgDto {
   @ApiProperty({
@@ -9,6 +9,7 @@ export class PatchUserImgDto {
   @IsString({
     message: "picture 是一段 URL。",
   })
+  @Length(1, 255, { message: "picture url 長度只能 1-255 個字元。" })
   public readonly picture: string;
   @ApiProperty({
     description: "背景圖",
@@ -17,5 +18,6 @@ export class PatchUserImgDto {
   @IsString({
     message: "background 是一段 URL。",
   })
+  @Length(1, 255, { message: "background url 長度只能 1-255 個字元。" })
   public readonly background: string;
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -104,11 +104,10 @@ export class UsersService {
       }
     });
 
-    const existingUser = await this.userRepository.find({
-      where: [{ email: user["email"] }, { username: user["username"] }],
-    });
-
-    if (existingUser) {
+    if (user["email"] || user["username"]) {
+      const existingUser = await this.userRepository.find({
+        where: [{ email: user["email"] }, { username: user["username"] }],
+      });
       const keys = ["email", "username"];
       const conflictedAttributes: string[] = [];
 


### PR DESCRIPTION
# Fix
When update userdata have error.
Because the where query, username and user email are the same, query becomes empty.
Change it to first check if either of these has been modified before proceeding with the query.
![image](https://github.com/IPFS-Blog/Backend/assets/77681849/23da77d6-e873-46f8-b605-5dde13835081)

# Refactor
Set character limits on all fields to prevent accidents.