### PR TITLE
fix: fix select comments' likes & select articles api

### DIFF
--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -39,6 +39,7 @@ export class ArticlesService {
         "article.contents",
         "article.release",
         "article.totalComments",
+        "article.likes",
         "article.ipfsHash",
         "article.createAt",
         "article.updateAt",

--- a/src/articles/comments/comments.service.ts
+++ b/src/articles/comments/comments.service.ts
@@ -156,7 +156,7 @@ export class CommentsService {
   }
 
   async getLikedComments(userId: number, aid: number) {
-    const queryBuilder = this.userRepository
+    const likes = await this.userRepository
       .createQueryBuilder("user")
       .leftJoinAndSelect("user.likeComments", "likeComments")
       .leftJoinAndSelect("likeComments.article", "article")
@@ -169,15 +169,16 @@ export class CommentsService {
         "likeComments.createAt",
         "likeComments.updateAt",
         "article.id",
-      ]);
-    if (aid != undefined) {
-      queryBuilder.andWhere("article.id = :aid", { aid });
-    }
+      ])
+      .getOne();
 
-    const likes = await queryBuilder.getOne();
+    const data: Comment[] = likes.likeComments.filter(
+      comment => comment.article.id === aid,
+    );
+
     return {
       statusCode: HttpStatus.OK,
-      comments: likes.likeComments,
+      comments: data,
     };
   }
 }


### PR DESCRIPTION
# Fix

`/api/v1/articles/user/comments/likes`
One should search through all the results first ,
and then find the desired comments on the articles, 
avoiding direct searches in linked tables.

`/api/v1/articles`
add the totoal number of article likes